### PR TITLE
build: split fhir db secret on its own stack

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -12,5 +12,12 @@ Run these commands on the terminal from the `./infra` folder of this repository:
 
 ```shell
 $ cdk bootstrap -c env=<env> # only needs to be run once
+$ cdk deploy -c env=<env> FHIRSecretsStack
+```
+
+Once the secrets stack is deployed, update the secret with the DB password and deploy the FHIR server
+with the command below:
+
+```shell
 $ cdk deploy -c env=<env> FHIRServerStack
 ```

--- a/infra/bin/infrastructure.ts
+++ b/infra/bin/infrastructure.ts
@@ -4,8 +4,10 @@ import "source-map-support/register";
 import { EnvConfig } from "../lib/env-config";
 import { EnvType } from "../lib/env-type";
 import { FHIRServerStack } from "../lib/fhir-server-stack";
+import { FHIRSecretsStack } from "../lib/fhir-secrets-stack";
 
 const app = new cdk.App();
+
 //-------------------------------------------
 // Parse config based on specified env
 //-------------------------------------------
@@ -40,6 +42,11 @@ async function deploy() {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: config.region,
   };
+
+  //---------------------------------------------------------------------------------
+  // Deploy the secrets stack.
+  //---------------------------------------------------------------------------------
+  new FHIRSecretsStack(app, "FHIRSecretsStack", { env, config });
 
   //---------------------------------------------------------------------------------
   // Deploy the FHIR server stack.

--- a/infra/lib/fhir-secrets-stack.ts
+++ b/infra/lib/fhir-secrets-stack.ts
@@ -1,0 +1,24 @@
+import { Stack, StackProps } from "aws-cdk-lib";
+import * as secret from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+import { EnvConfig } from "./env-config";
+
+interface SecretStackProps extends StackProps {
+  config: EnvConfig;
+}
+
+export const FHIR_DB_SECRET_NAME = "FHIRServerDBPasswordV2";
+
+export class FHIRSecretsStack extends Stack {
+  constructor(scope: Construct, id: string, props: SecretStackProps) {
+    super(scope, id, props);
+
+    new secret.Secret(this, FHIR_DB_SECRET_NAME, {
+      secretName: FHIR_DB_SECRET_NAME,
+      generateSecretString: {
+        excludePunctuation: true,
+        includeSpace: false,
+      },
+    });
+  }
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#378

### Dependencies

- Upstream: none
- Downstream: none

### Description

Create the FHIR db secret on its own stack so we can deploy it before the actual FHIR server.

### Release Plan

- [ ] deploy the secrets - a new secret will be created: `FHIRServerDBPasswordV2`
- [ ] update the new DB secret
- [ ] merge this - the FHIR server will be deployed
- [ ] once we verify the deployment finished, confirm the the old secret `FHIRServerDBPassword` was removed - if not, remove it manually