### PR TITLE
623 get private DNS zone from ID

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,8 @@ name: Java CI with Maven
 
 on:
   push:
+  pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -4,7 +4,7 @@ export type EnvConfig = {
   environmentType: EnvType;
   region: string;
   vpcId: string;
-  zone: string;
+  zoneId: string; // Route53 ID of the private hosted zone for this region
   domain: string;
   subdomain: string;
   dbName: string;

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -33,10 +33,11 @@ export class FHIRServerStack extends Stack {
     this.vpc = ec2.Vpc.fromLookup(this, "APIVpc", {
       vpcId: props.config.vpcId,
     });
-    this.zone = r53.HostedZone.fromLookup(this, "Zone", {
-      domainName: props.config.zone,
-      privateZone: true,
-    });
+    this.zone = r53.HostedZone.fromHostedZoneId(
+      this,
+      "FhirZone",
+      props.config.zoneId
+    );
 
     const slackNotification = setupSlackNotifSnsTopic(this, props.config);
 


### PR DESCRIPTION
Ref. metriport/metriport-internal#623

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/628
- Downstream: none

### Description

Get private DNS zone from ID

### Release Plan

- [x] update GH secret w/ base 64 of config
- [x] merge this