### PR TITLE
669 enable multi-tenancy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @metriport/devs

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,6 +6,10 @@ management:
       exposure:
         include: "health,prometheus"
 
+# https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.server
+server:
+  port: 8888 # not being picked up by Jetty embedded - gotta add `-Djetty.port=8888` for Jetty
+
 spring:
   main:
     allow-circular-references: true
@@ -22,7 +26,7 @@ spring:
 
     # database connection pool size
     hikari:
-      maximum-pool-size: 10
+      maximum-pool-size: 5
   jpa:
     properties:
       hibernate.format_sql: false
@@ -76,7 +80,7 @@ hapi:
   fhir:
 
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
-    openapi_enabled: false
+    openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
@@ -89,7 +93,7 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
-    server_address: https://localhost:8888/oauth/fhir
+    server_address: https://localhost:8080/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
     #    implementationguides:
@@ -145,9 +149,9 @@ hapi:
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
     mdm_enabled: false
-    #    partitioning:
-    #      allow_references_across_partitions: false
-    #      partitioning_include_in_search_hashes: false
+    partitioning:
+      allow_references_across_partitions: false
+      partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -126,9 +126,9 @@ hapi:
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
     mdm_enabled: false
-    #    partitioning:
-    #      allow_references_across_partitions: false
-    #      partitioning_include_in_search_hashes: false
+    partitioning:
+      allow_references_across_partitions: false
+      partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -57,7 +57,7 @@ hapi:
   fhir:
 
     ### This enables the swagger-ui at /fhir/swagger-ui/index.html as well as the /fhir/api-docs (see https://hapifhir.io/hapi-fhir/docs/server_plain/openapi.html)
-    openapi_enabled: false
+    openapi_enabled: true
     ### This is the FHIR version. Choose between, DSTU2, DSTU3, R4 or R5
     fhir_version: R4
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
@@ -71,7 +71,6 @@ hapi:
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
     server_address: https://api.staging.metriport.com/oauth/fhir
-    # server_address: https://fhir.metriport.com/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
     #    implementationguides:
@@ -127,9 +126,9 @@ hapi:
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
     mdm_enabled: false
-    #    partitioning:
-    #      allow_references_across_partitions: false
-    #      partitioning_include_in_search_hashes: false
+    partitioning:
+      allow_references_across_partitions: false
+      partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/669

### Dependencies

- upstream: none
- downstream: https://github.com/metriport/metriport/pull/316

### Description

- enable multi-tenancy
- add `CODEOWNERS`

### Release Plan

- [ ] wait for downstream to be ready to be merged
- [ ] merge this and downstream
- ⚠️ When deploying this on `production`, those merges ^ might break requests going through at the time, since there's no backwards compatibility built in this PR - deploy off office hours