### PR TITLE
738 Update DB IOPS alarm

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -352,7 +352,7 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeReadIOPsAlarm`,
       {
-        threshold: 20000, // IOPs per second
+        threshold: 60_000, // IOPs per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
@@ -365,17 +365,13 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeWriteIOPsAlarm`,
       {
-        threshold: 5000, // IOPs per second
+        threshold: 40_000, // IOPs per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
     );
     alarmAction && writeAlarm.addAlarmAction(alarmAction);
     alarmAction && writeAlarm.addOkAction(alarmAction);
-  }
-
-  private isProd(props: FHIRServerProps): boolean {
-    return isProd(props.config);
   }
 }
 


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/738

### Dependencies

none

### Description

Update DB IOPS alarm

This has already been applied to `prod` - [context](https://metriport.slack.com/archives/C04DBBJSKGB/p1685586829400919?thread_ts=1685569573.211009&cid=C04DBBJSKGB).

### Release Plan

- deploy in staging, no need to deploy to prod
- update dashboards in prod and staging