### PR TITLE
fix(api): remove fhir server caching so latest data is always returned

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -187,7 +187,7 @@ hapi:
     #    max_binary_size: 104857600
     #    max_page_size: 200
     #    retain_cached_searches_mins: 60
-    #    reuse_cached_search_results_millis: 60000
+    reuse_cached_search_results_millis: 0
     # tester:
     #   home:
     #     name: Local Tester

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -166,7 +166,7 @@ hapi:
     #    max_binary_size: 104857600
     #    max_page_size: 200
     #    retain_cached_searches_mins: 60
-    #    reuse_cached_search_results_millis: 60000
+    reuse_cached_search_results_millis: 0
     # tester:
     #   home:
     #     name: Local Tester

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -166,7 +166,7 @@ hapi:
     #    max_binary_size: 104857600
     #    max_page_size: 200
     #    retain_cached_searches_mins: 60
-    #    reuse_cached_search_results_millis: 60000
+    reuse_cached_search_results_millis: 0
     # tester:
     #   home:
     #     name: Local Tester

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -168,7 +168,7 @@ hapi:
     #    max_binary_size: 104857600
     #    max_page_size: 200
     #    retain_cached_searches_mins: 60
-    #    reuse_cached_search_results_millis: 60000
+    reuse_cached_search_results_millis: 0
     # tester:
     #   home:
     #     name: Local Tester


### PR DESCRIPTION
refs. metriport/metriport-internal#815

### Dependencies

N/A

### Description

remove fhir server caching so latest data is always returned

### Release Plan

- merge develop to master
- manual release thru cdk
