### PR TITLE
fix(fhir): increased write IOPS threshold to 100_000

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -379,7 +379,7 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeWriteIOPsAlarm`,
       {
-        threshold: 40_000, // IOPs per second
+        threshold: 100_000, // IOPs per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }


### PR DESCRIPTION
refs. metriport/metriport-internal#1065

### Dependencies

- Downstream: https://github.com/metriport/metriport/pull/917

### Description

- Increased the WriteIOPS alarm threshold to 100_000

### Release Plan

- Nothing special
