### PR TITLE
RELEASE 2023-09-26

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -379,7 +379,7 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeWriteIOPsAlarm`,
       {
-        threshold: 40_000, // IOPs per second
+        threshold: 100_000, // IOPs per second
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }

--- a/infra/lib/util.ts
+++ b/infra/lib/util.ts
@@ -5,6 +5,10 @@ export function isProd(config: EnvConfig): boolean {
   return config.environmentType === EnvType.production;
 }
 
+export function isSandbox(config: EnvConfig): boolean {
+  return config.environmentType === EnvType.sandbox;
+}
+
 export function mbToBytes(mb: number): number {
   return mb * 1024 * 1024;
 }


### PR DESCRIPTION
Ref: #https://github.com/metriport/metriport-internal/issues/1065

### Description

- FHIRServerStack-fhirserverVolumeWriteIOPsAlarm threshold to 100_000

### Release Plan

- ⚠️ Pointing to master
- Merge this
- Confirm the threshold got adjusted: https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#alarmsV2:alarm/FHIRServerStack-fhirserverVolumeWriteIOPsAlarm7751AC22-102529MHWVUP1?~(search~'FHIRServerStack-fhirserverVolumeWriteIOPsAlarm)
