### PR TITLE
1040 adjust volume IOPS alarms

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -366,7 +366,7 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeReadIOPsAlarm`,
       {
-        threshold: 60_000, // IOPs per second
+        threshold: 300_000, // IOPS
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }
@@ -379,7 +379,7 @@ export class FHIRServerStack extends Stack {
       this,
       `${dbClusterName}VolumeWriteIOPsAlarm`,
       {
-        threshold: 100_000, // IOPs per second
+        threshold: 300_000, // IOPS
         evaluationPeriods: 1,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       }


### PR DESCRIPTION
Ref: metriport/metriport-internal#1040

### Dependencies

related: https://github.com/metriport/metriport/pull/1191

### Description

Adjust volume IOPS alarms - [context](https://metriport.slack.com/archives/C04T256DQPQ/p1700085330705119?thread_ts=1700083339.157099&cid=C04T256DQPQ)

Maximum in 6 weeks:

<img width="2004" alt="image" src="https://github.com/metriport/fhir-server/assets/2132564/c9411e51-e1ee-4705-85b6-d00f394d993b">

ACU Utilization always under 30% (P99) - [link to chart](https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#metricsV2?graph=~(metrics~(~(~'AWS*2fRDS~'VolumeWriteIOPs~'DBClusterIdentifier~'fhir-server~(yAxis~'right))~(~'.~'VolumeReadIOPs~'.~'.~(yAxis~'right))~(~'.~'ACUUtilization~'.~'.~(stat~'p99)))~view~'timeSeries~stacked~false~region~'us-west-1~stat~'Maximum~period~86400~title~'FHIR*20DB*20-*20IOPS~liveData~false~annotations~(horizontal~(~(label~'VolumeWriteIOPs*20*3e*3d*2010_000*20for*201*20datapoints*20within*205*20minutes~value~10000~yAxis~'right)))~start~'-PT1008H~end~'P0D)&query=~'*7bAWS*2fRDS*2cDBClusterIdentifier*7d*20ACUUtilization)

### Release Plan

- nothing special
- update the dashboard's threshold after this is merged/released