### PR TITLE
fix: updating server_address on local and adding depdency comment

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -93,7 +93,10 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
-    server_address: https://localhost:8080/oauth/fhir
+    # ******* IMPORTANT *******
+    # Adjusting server_address requires updating the proxy string replace function in the API Project
+    # *************************
+    server_address: http://127.0.0.1:8080/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
     #    implementationguides:

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -72,6 +72,9 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ## enable to set the Server URL
+    # ******* IMPORTANT *******
+    # Adjusting server_address requires updating the proxy string replace function in the API Project
+    # *************************
     server_address: https://api.metriport.com/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -72,6 +72,9 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
+    # ******* IMPORTANT *******
+    # Adjusting server_address requires updating the proxy string replace function in the API Project
+    # *************************
     server_address: https://api.sandbox.metriport.com/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -72,6 +72,9 @@ hapi:
     ### the deepest folder level will be used. E.g. - if you put file:/foo/bar/bazz as value then the files are resolved under /static/bazz/**
     #staticLocation: file:/foo/bar/bazz
     ### enable to set the Server URL
+    # ******* IMPORTANT *******
+    # Adjusting server_address requires updating the proxy string replace function in the API Project
+    # *************************
     server_address: https://api.staging.metriport.com/oauth/fhir
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true


### PR DESCRIPTION
Ref: #1719

### Description

- Adjusted local url to match current `.env` API URL value (currently `http://127.0.0.1`)
- Added dependency comment nothing editing the `server_address` requires editing the proxy string replace function

### Release Plan

- [ ] Merge this
