### PR TITLE
1743 Add alarms for SOC2 controls

### DIFF
--- a/infra/lib/shared/cloudwatch-metric.ts
+++ b/infra/lib/shared/cloudwatch-metric.ts
@@ -1,0 +1,35 @@
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Construct } from "constructs";
+
+export function addAlarmToMetric({
+  scope,
+  metric,
+  alarmName,
+  threshold,
+  evaluationPeriods,
+  comparisonOperator,
+  treatMissingData,
+  alarmAction,
+  includeOkAction = true,
+}: {
+  scope: Construct;
+  metric: Metric;
+  alarmName: string;
+  threshold: number;
+  evaluationPeriods: number;
+  comparisonOperator?: ComparisonOperator;
+  treatMissingData?: TreatMissingData;
+  alarmAction?: SnsAction;
+  includeOkAction?: boolean;
+}): Alarm {
+  const alarm = metric.createAlarm(scope, alarmName, {
+    threshold,
+    evaluationPeriods,
+    comparisonOperator,
+    treatMissingData,
+  });
+  alarmAction && alarm.addAlarmAction(alarmAction);
+  alarmAction && includeOkAction && alarm.addOkAction(alarmAction);
+  return alarm;
+}

--- a/infra/lib/shared/target-group.ts
+++ b/infra/lib/shared/target-group.ts
@@ -1,0 +1,52 @@
+import { Duration } from "aws-cdk-lib";
+import { ComparisonOperator, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { ApplicationTargetGroup, HttpCodeTarget } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Construct } from "constructs";
+import { addAlarmToMetric } from "../shared/cloudwatch-metric";
+
+export function addDefaultMetricsToTargetGroup({
+  targetGroup,
+  scope,
+  id,
+  idx = 0,
+  alarmAction,
+}: {
+  targetGroup: ApplicationTargetGroup;
+  scope: Construct;
+  id: string;
+  idx?: number;
+  alarmAction?: SnsAction;
+}) {
+  const name = `${id}_TargetGroup${idx}`;
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.unhealthyHostCount(),
+    alarmName: `${name}_UnhealthyRequestCount`,
+    threshold: 1,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.targetResponseTime(),
+    alarmName: `${name}_TargetResponseTime`,
+    threshold: Duration.seconds(29).toSeconds(),
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+  addAlarmToMetric({
+    scope,
+    metric: targetGroup.metrics.httpCodeTarget(HttpCodeTarget.TARGET_5XX_COUNT),
+    alarmName: `${name}_Target5xxCount`,
+    threshold: 5,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+    alarmAction,
+  });
+}


### PR DESCRIPTION
Ref. metriport/metriport-internal#1734

### Dependencies

- Upstream: https://github.com/metriport/metriport/pull/1998
- Downstream: none
- Related: https://github.com/metriport/metriport/pull/2006

### Description

- add DB deletion protection
- set DB removal policy to retain
- add alarm to DB free local storage
- add ALB metrics/alarms

Used the same code and metrics that we used for OSS.

### Testing

- Staging
  - [ ] successful deployment
- Sandbox
  - [ ] successful deployment
- Production
  - [ ] successful deployment
  - [ ] SOC2 controls passing

### Release Plan

- [ ] Merge this