### PR TITLE
626 Fix FHIRServer CICD

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -63,6 +63,7 @@ jobs:
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
+          INPUT_PATH: "infra"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
@@ -76,6 +77,7 @@ jobs:
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
+          INPUT_PATH: "infra"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -59,7 +59,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
-          cdk_version: "2.49.0"
+          cdk_version: "2.122.0"
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -73,7 +73,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.49.0"
+          cdk_version: "2.122.0"
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:

--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -53,6 +53,15 @@ jobs:
       # INSTALL DEPENDENCIES
       - name: Install NodeJS dependencies
         run: npm ci --ignore-scripts
+        working-directory: "./infra"
+
+      - name: Build
+        run: npm run build
+        working-directory: "./infra"
+
+      - name: Test
+        run: npm run test
+        working-directory: "./infra"
 
       # CDK DIFF
       - name: Diff CDK stack

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -237,7 +237,7 @@ export class FHIRServerStack extends Stack {
           publicLoadBalancer: false,
           idleTimeout: maxExecutionTimeout,
           runtimePlatform: {
-            cpuArchitecture: ecs.CpuArchitecture.ARM64,
+            cpuArchitecture: ecs.CpuArchitecture.X86_64,
             operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
           },
         }

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,8 +8,8 @@
       "name": "infrastructure",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.87.0",
-        "constructs": "^10.1.144",
+        "aws-cdk-lib": "2.122.0",
+        "constructs": "^10.2.69",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -22,7 +22,7 @@
         "@types/prettier": "2.7.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
-        "aws-cdk": "2.87.0",
+        "aws-cdk": "2.122.0",
         "esbuild": "^0.15.12",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
@@ -56,10 +56,10 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.166",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.166.tgz",
-      "integrity": "sha512-j0xnccpUQHXJKPgCwQcGGNu4lRiC1PptYfdxBIH1L4dRK91iBxtSQHESRQX+yB47oGLaF/WfNN/aF3WXwlhikg=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1740,9 +1740,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.87.0.tgz",
-      "integrity": "sha512-dBm74nl3dMUxoAzgjcfKnzJyoVNIV//B1sqDN11cC3LXEflYapcBxPxZHAyGcRXg5dW3m14dMdKVQfmt4N970g==",
+      "version": "2.122.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.122.0.tgz",
+      "integrity": "sha512-WqiVTedcuW4LjH4WqtQncliUdeDa9j9xgu3II8Qd1HmCZotbzBorYIHDvOJ+m3ovIzd9DL+hNq9PPUqxtBe0VQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1755,9 +1755,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.87.0.tgz",
-      "integrity": "sha512-9kirXX7L7OP/yGmCbaYlkt5OAtowGiGw0AYFIQvSwvx/UU3aJO5XuDwAgDsvToDkRpBi0yX0bNwqa0DItu+C6A==",
+      "version": "2.122.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.122.0.tgz",
+      "integrity": "sha512-NBUfYk/SialvKFsvBG/Ucd7lM+BID3Uy3EEOnIBbioDpnMotm5SDaU/RUm4APS4sxzQZX1DjduD5ZUFNHnEWhQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1771,17 +1771,17 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.201",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.2.4",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.0",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.5.1",
+        "punycode": "^2.3.1",
+        "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -1896,7 +1896,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1914,7 +1914,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
+      "version": "5.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1981,7 +1981,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1997,7 +1997,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.5.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2066,7 +2066,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2402,11 +2402,11 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.255",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.255.tgz",
-      "integrity": "sha512-m7ddP9mF92096r4/2oqUg8sUYNdt7x2tjRSltnTtgvqiasBr0gSjzLkHqlGR0IrnvQWemv1kA1GESWxYAK20vw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
+      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
       "engines": {
-        "node": ">= 14.17.0"
+        "node": ">= 16.14.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -4911,6 +4911,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/infra/package.json
+++ b/infra/package.json
@@ -19,7 +19,7 @@
     "@types/prettier": "2.7.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
-    "aws-cdk": "2.87.0",
+    "aws-cdk": "2.122.0",
     "esbuild": "^0.15.12",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
@@ -30,8 +30,8 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.87.0",
-    "constructs": "^10.1.144",
+    "aws-cdk-lib": "2.122.0",
+    "constructs": "^10.2.69",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#626

### Dependencies

- upstream: https://github.com/metriport/fhir-server/pull/52

### Description

FIxes to FHIR Server's CICD:
- set input path when calling deploy-with-cdk
- update CDK to same version of OSS repo
- change runtime architecture from ARM to x86

### Testing

- staging
   - [ ] deployment is successful
   - [ ] query org and patient on FHIR server 
- production
   - [ ] query org and patient on FHIR server 

### Release Plan

- [x] enable staging workflow on GH
- [x] enable production workflow on GH
- [ ] merge this