### PR TITLE
626 Remove tmp env var from ECS

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -231,7 +231,6 @@ export class FHIRServerStack extends Stack {
               SPRING_PROFILES_ACTIVE: props.config.environmentType,
               DB_URL: dbUrl,
               DB_USERNAME: dbCreds.username,
-              TEMPORARY: "temporary-env-var",
             },
           },
           healthCheckGracePeriod: Duration.seconds(120),


### PR DESCRIPTION
Ref. metriport/metriport-internal#626

### Dependencies

- upstream: https://github.com/metriport/fhir-server/pull/58

### Description

Remove temporary env var from ECS

### Testing

- staging
   - [ ] deployment is successful
- production
   - none

### Release Plan

- [ ] merge this