### PR TITLE
626 Merge master into develop + update docker compose for FHIR converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ You can use the `docker-compose` to run the app and DB servers by executing the 
 $ docker-compose up --build
 ```
 
+To run the secondary app and Servers for testing run:
+```shell 
+$ docker compose -p fhirconverter -f docker-compose-fhir-converter.yml up -d
+```
+⚠️ **WARNING**: This secondary instance is used for testing purposes only. Data within this instance is constantly deleted as part of the normal testing workflow. Do not use it for any purposes that require data to persist for more than a few minutes.
+
 Run the server from the docker image, on a specific Spring profile (in this case, `application-staging.yaml`), with environment variables being passed to the docker container:
 
 Update environment variables in the `docker-compose.yml` file accordingly.

--- a/docker-compose-fhir-converter.yml
+++ b/docker-compose-fhir-converter.yml
@@ -1,0 +1,35 @@
+version: "3"
+services:
+  fhir-server-fhir-converter:
+    build: .
+    container_name: fhir-server-fhir-converter
+    depends_on:
+      fhir-postgres-fhir-converter:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: "local"
+      DB_USERNAME: "admin"
+      DB_PASSWORD: "admin"
+      DB_URL: "jdbc:postgresql://fhir-postgres-fhir-converter:5432/db"
+    restart: on-failure
+    ports:
+      - "8889:8888"
+  fhir-postgres-fhir-converter:
+    image: postgres:14.4-alpine
+    container_name: fhir-postgres-fhir-converter
+    restart: always
+    environment:
+      POSTGRES_DB: "db"
+      POSTGRES_USER: "admin"
+      POSTGRES_PASSWORD: "admin"
+    ports:
+      - "5437:5432"
+    volumes:
+      - fhir-postgres-fhir-converter:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      interval: 2s
+      timeout: 2s
+      retries: 2
+volumes:
+  fhir-postgres-fhir-converter:

--- a/docker-compose-fhir-converter.yml
+++ b/docker-compose-fhir-converter.yml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   fhir-server-fhir-converter:
-    build: .
+    build:
+      context: ./
+      dockerfile: ./Dockerfile.dev
     container_name: fhir-server-fhir-converter
     depends_on:
       fhir-postgres-fhir-converter:


### PR DESCRIPTION
Ref: https://github.com/metriport/metriport-internal/issues/626

### Dependencies

none

### Description

- Back-merge `master` into `develop`
   - After merging [this patch](https://github.com/metriport/fhir-server/pull/47) into master we never backmerged into develop
- Update docker compose for fhir converter to also point to the dev dockerfile

### Release Plan

- Nothing special