### PR TITLE
1040 Add Thomas as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Goncharo @leite08 @Orta21 @RamilGaripov @jonahkaye
+* @Goncharo @leite08 @Orta21 @RamilGaripov @jonahkaye @thomasyopes


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Description

Add Thomas as codeowner

### Release Plan

- Merge this, no release expected.
