### PR TITLE
1040 Readjust RDS min size on staging to 1 ACU

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -78,7 +78,7 @@ export function settings(): Settings {
     memoryLimitMiB: 2048,
     taskCountMin: 1,
     taskCountMax: 5,
-    minDBCap: 0.5,
+    minDBCap: 1,
     maxDBCap: 8,
   };
 }


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/65
- Downstream: none

### Description

Readjust RDS min size on staging to 1 ACU.

During the tests for [this PR](https://github.com/metriport/metriport/pull/2542), the DB went to 100% ACU w/o much stuff ongoing. So I think its better to have at least 1 full ACU to avoid us having issues when testing on staging.

![image](https://github.com/user-attachments/assets/c109b0b6-8c0e-463c-9416-7cc865e4b200)

[source](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#metricsV2?graph=~(metrics~(~(~'AWS*2fRDS~'ACUUtilization~'DBInstanceIdentifier~'fhir-serverinstance1~(label~'fhir-serverinstance1~region~'us-east-2)))~period~300~region~'us-east-2~stat~'p99~title~'ACUUtilization~yAxis~(left~(min~0))~start~'-PT1H~end~'P0D~view~'timeSeries~stacked~false))

### Release Plan

- Merge this