### PR TITLE
1040 Update RDS engine minor version and add retain policy to its logs

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -28,6 +28,7 @@ import { getConfig } from "./shared/config";
 import { vCPU } from "./shared/fargate";
 import { addDefaultMetricsToTargetGroup } from "./shared/target-group";
 import { isProd, isSandbox, mbToBytes } from "./util";
+import { RetentionDays } from "aws-cdk-lib/aws-logs";
 
 type Settings = {
   cpu: number;
@@ -179,7 +180,7 @@ export class FHIRServerStack extends Stack {
     }
     const dbCluster = new rds.DatabaseCluster(this, "FHIR_DB", {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
-        version: rds.AuroraPostgresEngineVersion.VER_14_4,
+        version: rds.AuroraPostgresEngineVersion.VER_14_7,
       }),
       instanceProps: {
         vpc: this.vpc,
@@ -191,6 +192,7 @@ export class FHIRServerStack extends Stack {
       storageEncrypted: true,
       parameterGroup,
       cloudwatchLogsExports: ["postgresql"],
+      cloudwatchLogsRetention: RetentionDays.ONE_YEAR,
       deletionProtection: true,
       removalPolicy: RemovalPolicy.RETAIN,
     });


### PR DESCRIPTION
Ref. metriport/metriport-internal#1040

### Dependencies

- Related:
   - https://github.com/metriport/metriport-internal/pull/2098
   - https://github.com/metriport/metriport/pull/2585

### Description

- update RDS engine minor version
   - we're running the OSS DB at `14.7` for months now, and there are important improvements since v14.4 ([aws releases](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html#aurorapostgresql-versions-version14), [postgres releases](https://www.postgresql.org/docs/release/))
- add retain policy to RDS logs

### Testing

- Staging
  - [ ] RDS updated according to changes
  - [ ] Buckets w/ request metrics
- Production
  - [ ] RDS updated according to changes
  - [ ] Buckets w/ request metrics

### Release Plan

- ⚠️ This will restart our FHIR DB
- [ ] Merge this
