### PR TITLE
ENG-000 Fix CDK CLI and Lib versions + Update min ACU

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -35,8 +35,8 @@ Deploy() {
     cmd="deploy"
   fi
   echo "$cmd'ing to env $env"
-  cdk bootstrap -c env=$env
-  cdk $cmd -c env=$env FHIRServerStack
+  npx cdk bootstrap -c env=$env
+  npx cdk $cmd -c env=$env FHIRServerStack
   echo "Done!"
 }
 

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -60,7 +60,7 @@ export function settings(): Settings {
       taskCountMin: 8,
       taskCountMax: 20,
       minDBCap: 20,
-      maxDBCap: 196,
+      maxDBCap: 128,
       backupRetentionDays: 15,
     };
   }
@@ -83,7 +83,7 @@ export function settings(): Settings {
     taskCountMin: 1,
     taskCountMax: 5,
     minDBCap: 0.5,
-    maxDBCap: 9,
+    maxDBCap: 8,
     backupRetentionDays: 1,
   };
 }

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -83,7 +83,7 @@ export function settings(): Settings {
     taskCountMin: 1,
     taskCountMax: 5,
     minDBCap: 0.5,
-    maxDBCap: 8,
+    maxDBCap: 9,
     backupRetentionDays: 1,
   };
 }

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,7 +8,7 @@
       "name": "infrastructure",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.239.0",
+        "aws-cdk-lib": "^2.214.0",
         "constructs": "^10.2.69",
         "source-map-support": "^0.5.21"
       },
@@ -22,7 +22,7 @@
         "@types/prettier": "2.7.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
-        "aws-cdk": "^2.122.0",
+        "aws-cdk": "^2.1029.1",
         "esbuild": "^0.15.12",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
@@ -1770,18 +1770,15 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.122.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.122.0.tgz",
-      "integrity": "sha512-WqiVTedcuW4LjH4WqtQncliUdeDa9j9xgu3II8Qd1HmCZotbzBorYIHDvOJ+m3ovIzd9DL+hNq9PPUqxtBe0VQ==",
+      "version": "2.1106.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1106.1.tgz",
+      "integrity": "sha512-oSKAvM6a5dVNb+OZoLyjLe2rIkG6URVRHN+cOUZM9uEScYDYPn2KpOQ1iGofH6szsJp76GqQqpiwEpaYXrIHmw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -3595,6 +3592,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4987,6 +4985,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5146,6 +5145,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5160,6 +5160,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5170,7 +5171,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -19,7 +19,7 @@
     "@types/prettier": "2.7.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
-    "aws-cdk": "^2.122.0",
+    "aws-cdk": "^2.1029.1",
     "esbuild": "^0.15.12",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
@@ -30,7 +30,7 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.239.0",
+    "aws-cdk-lib": "^2.214.0",
     "constructs": "^10.2.69",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/84
- Downstream: none

### Description

Update min ACU from 15 to 20 it runs always above 15%, so scaling to 20 makes it more responsive to get more ACU faster when needed:

<img width="1882" height="784" alt="image" src="https://github.com/user-attachments/assets/9a85bf09-5824-469d-9868-0dd38cd80e84" />

CDK CLI and lib matching - context [1](https://metriport.slack.com/archives/C04DMKE9DME/p1771825449031909?thread_ts=1771700932.580089&cid=C04DMKE9DME) and [2](https://github.com/metriport/fhir-server/actions/runs/22294364574/job/64487905292).

Reference: [updating CDK on OSS repo](https://github.com/metriport/metriport-private/pull/65/files#diff-e1bf8f1209c5ab34f8507a5a3a8f374388cee71d4170189f5efa1b3a07389ab2)

### Testing

- Local
  - [x] `cdk diff` works
- Staging
  - [x] Deploy works
  - [x] FHIR DB max ACU updated w/o restart
- Sandbox
  - none
- Production
  - none

### Metrics

none

### Release Plan

- [ ] Merge this
