### PR TITLE
ENG-000 Fix CDK version on CICD + Add retention policy do RDS' logs

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -68,7 +68,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "diff"
-          cdk_version: "2.122.0"
+          cdk_version: "2.1029.4"
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
@@ -82,7 +82,7 @@ jobs:
         uses: metriport/deploy-with-cdk@master
         with:
           cdk_action: "deploy --verbose --require-approval never"
-          cdk_version: "2.122.0"
+          cdk_version: "2.1029.4"
           cdk_stack: "FHIRServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -28,6 +28,7 @@ import { getConfig } from "./shared/config";
 import { vCPU } from "./shared/fargate";
 import { addDefaultMetricsToTargetGroup } from "./shared/target-group";
 import { isProd, isSandbox, mbToBytes } from "./util";
+import { RetentionDays } from "aws-cdk-lib/aws-logs";
 
 type Settings = {
   cpu: number;
@@ -198,6 +199,7 @@ export class FHIRServerStack extends Stack {
       storageEncrypted: true,
       parameterGroup,
       cloudwatchLogsExports: ["postgresql"],
+      cloudwatchLogsRetention: RetentionDays.ONE_YEAR,
       deletionProtection: true,
       removalPolicy: RemovalPolicy.RETAIN,
       backup: {

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -22,7 +22,7 @@
         "@types/prettier": "2.7.1",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
-        "aws-cdk": "^2.1029.1",
+        "aws-cdk": "^2.1029.4",
         "esbuild": "^0.15.12",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",

--- a/infra/package.json
+++ b/infra/package.json
@@ -19,7 +19,7 @@
     "@types/prettier": "2.7.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
-    "aws-cdk": "^2.1029.1",
+    "aws-cdk": "^2.1029.4",
     "esbuild": "^0.15.12",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/85
- Downstream: none

### Description

- Update cdk version on CICD workflow and match on `package.json` - [context](https://metriport.slack.com/archives/C04FZ9859FZ/p1772127227089489?thread_ts=1772126200.066299&cid=C04FZ9859FZ)
- Add missing retention policy to RDS logs - implements change from https://github.com/metriport/fhir-server/pull/71 so we can close that

### Testing

- staging
   - [x] DB logs older than 1 year are deleted

### Metrics

none

### Release Plan

- [ ] Merge this
