### PR TITLE
ENG-000 Revert min ACU on FHIR DB

### DIFF
--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -60,7 +60,7 @@ export function settings(): Settings {
       memoryLimitMiB: 8192,
       taskCountMin: 8,
       taskCountMax: 20,
-      minDBCap: 20,
+      minDBCap: 15,
       maxDBCap: 128,
       backupRetentionDays: 15,
     };


### PR DESCRIPTION
### Dependencies

- Upstream: https://github.com/metriport/fhir-server/pull/84/files
- Downstream: none

### Description

Revert min ACU from 20 to 15 - [context](https://metriport.slack.com/archives/C04CXLSAF7V/p1772132201622179?thread_ts=1772131105.341379&cid=C04CXLSAF7V)

### Testing

none

### Metrics

none

### Release Plan

- [ ] Merge this
