### PR TITLE
eng2449: add duration and fix duplicate fields in log

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -598,11 +598,19 @@ public class AppProperties {
 
   }
 
+  /**
+   * @see https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/LoggingInterceptor.java
+   */
   public static class Logger {
 
     private String name = "fhirtest.access";
-    private String error_format = "ERROR - ${requestVerb} ${requestUrl}";
-    private String format = "Path[${servletPath}] Source[${requestHeader.x-forwarded-for}] Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}] Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}]";
+
+    private String format =
+        "Path[${servletPath}] Source[${requestHeader.x-forwarded-for}] "
+            + "Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] "
+            + "Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}] Ms[${processingTimeMillis}]";
+
+    private String error_format = "ERROR " + format + " Exception[${exceptionMessage}]";
     private Boolean log_exceptions = true;
 
     public String getName() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -605,10 +605,9 @@ public class AppProperties {
 
     private String name = "fhirtest.access";
 
-    private String format =
-        "Path[${servletPath}] Source[${requestHeader.x-forwarded-for}] "
-            + "Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] "
-            + "Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}] Ms[${processingTimeMillis}]";
+    private String format = "Path[${servletPath}] Source[${requestHeader.x-forwarded-for}] "
+      + "Operation[${operationType} ${operationName} ${idOrResourceName}] UA[${requestHeader.user-agent}] "
+      + "Params[${requestParameters}] ResponseEncoding[${responseEncodingNoDefault}] Ms[${processingTimeMillis}]";
 
     private String error_format = "ERROR " + format + " Exception[${exceptionMessage}]";
     private Boolean log_exceptions = true;


### PR DESCRIPTION
refs. eng#2449

### Dependencies

- Upstream: None
- Downstream: None

### Description

- Add duration timing to log lines
- Remove duplicate log fields

### Testing

- Local
  - N/A
- Staging
  - [x] No errors on a DQ run w/o new docs to download
  - [x] No errors on a DQ run w/ new docs to download
  - [x] Logs include duration

### Release Plan

- [x] Merge this
