### PR TITLE
feat(fhir-config): define default and max page size

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -122,8 +122,8 @@ hapi:
     #    cr_enabled: true
     #    ips_enabled: false
     #    default_encoding: JSON
-    #    default_pretty_print: true
-    #    default_page_size: 20
+    default_pretty_print: false
+    default_page_size: 50
     delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: true
     #    enable_index_missing_fields: false
@@ -184,7 +184,7 @@ hapi:
     #      log_exceptions: true
     #      name: fhirtest.access
     #    max_binary_size: 104857600
-    #    max_page_size: 200
+    max_page_size: 500
     #    retain_cached_searches_mins: 60
     reuse_cached_search_results_millis: 0
     # tester:

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -101,8 +101,8 @@ hapi:
     #    cr_enabled: true
     #    ips_enabled: false
     #    default_encoding: JSON
-    #    default_pretty_print: true
-    #    default_page_size: 20
+    default_pretty_print: false
+    default_page_size: 50
     delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: true
     #    enable_index_missing_fields: false
@@ -163,7 +163,7 @@ hapi:
     #      log_exceptions: true
     #      name: fhirtest.access
     #    max_binary_size: 104857600
-    #    max_page_size: 200
+    max_page_size: 500
     #    retain_cached_searches_mins: 60
     reuse_cached_search_results_millis: 0
     # tester:

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -101,8 +101,8 @@ hapi:
     #    cr_enabled: true
     #    ips_enabled: false
     #    default_encoding: JSON
-    #    default_pretty_print: true
-    #    default_page_size: 20
+    default_pretty_print: false
+    default_page_size: 50
     delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: true
     #    enable_index_missing_fields: false
@@ -163,7 +163,7 @@ hapi:
     #      log_exceptions: true
     #      name: fhirtest.access
     #    max_binary_size: 104857600
-    #    max_page_size: 200
+    max_page_size: 500
     #    retain_cached_searches_mins: 60
     reuse_cached_search_results_millis: 0
     # tester:

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -103,8 +103,8 @@ hapi:
     #    cr_enabled: true
     #    ips_enabled: false
     #    default_encoding: JSON
-    #    default_pretty_print: true
-    #    default_page_size: 20
+    default_pretty_print: false
+    default_page_size: 50
     delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: true
     #    enable_index_missing_fields: false
@@ -165,7 +165,7 @@ hapi:
     #      log_exceptions: true
     #      name: fhirtest.access
     #    max_binary_size: 104857600
-    #    max_page_size: 200
+    max_page_size: 500
     #    retain_cached_searches_mins: 60
     reuse_cached_search_results_millis: 0
     # tester:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -80,8 +80,8 @@ hapi:
     #    auto_create_placeholder_reference_targets: false
     #    cr_enabled: true
     #    default_encoding: JSON
-    #    default_pretty_print: true
-    #    default_page_size: 20
+    default_pretty_print: false
+    default_page_size: 50
     #    delete_expunge_enabled: true
     #    enable_repository_validating_interceptor: false
     #    enable_index_missing_fields: false
@@ -134,7 +134,7 @@ hapi:
     #      log_exceptions: true
     #      name: fhirtest.access
     #    max_binary_size: 104857600
-    #    max_page_size: 200
+    max_page_size: 500
     #    retain_cached_searches_mins: 60
     #    reuse_cached_search_results_millis: 60000
     tester:


### PR DESCRIPTION
https://linear.app/metriport/issue/ENG-2402/optimize-current-hapi-fhir-server-install

### Dependencies

- Upstream: None
- Downstream: None

### Description

Updating `default_page_size` and `max_page_size` in the yaml.

From the logs, we’re seeing a lot of paginated reads using _count=20, which likely means clients are pulling large result sets across many small pages. Increasing default_page_size should reduce the number of get-page requests needed to retrieve DocumentReferences, which can lower repeated paging overhead and overall ECS load.

We should also explicitly set max_page_size as a safety guardrail. If the default is effectively very large, a client could request an unexpectedly huge page size and force the server to blow up. Right now it defaults to java max int size


### Testing

- Staging
  - [x] Run DQ on staging
  - [x] Check get-page _count
  - [x] Check if explicity send _count > 500
- Production
  - [ ] Check ECS cluster health
  - [x] Check logs for get-page _count
  - [x] Check overall logs
  - [ ] Check explicity send _count > 500

### Release Plan
- [x] Merge this
