### PR TITLE
feat(fhir-config): disable full text search

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -42,7 +42,6 @@ spring:
   #      hibernate.cache.use_second_level_cache: false
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
-  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
       hibernate.search.enabled: false
   # security:
   #   oauth2:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -42,17 +42,8 @@ spring:
   #      hibernate.cache.use_second_level_cache: false
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
-  ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
-  ### lucene parameters
-#      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-#      hibernate.search.backend.directory.type: local-filesystem
-#      hibernate.search.backend.directory.root: target/lucenefiles
-#      hibernate.search.backend.lucene_version: lucene_current
-  ### elastic parameters ===> see also elasticsearch section below <===
-#      hibernate.search.backend.type: elasticsearch
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
+  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
+      hibernate.search.enabled: false
   # security:
   #   oauth2:
   #     client:
@@ -114,7 +105,7 @@ hapi:
     ##################################################
     #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
     allow_cascading_deletes: true
-    #    allow_contains_searches: true
+    allow_contains_searches: false
     allow_external_references: true
     allow_multiple_delete: true
     #    allow_override_default_search_params: true

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -44,17 +44,8 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
-  ### lucene parameters
-#      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-#      hibernate.search.backend.directory.type: local-filesystem
-#      hibernate.search.backend.directory.root: target/lucenefiles
-#      hibernate.search.backend.lucene_version: lucene_current
-  ### elastic parameters ===> see also elasticsearch section below <===
-#      hibernate.search.backend.type: elasticsearch
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
+  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
+      hibernate.search.enabled: false
 hapi:
   fhir:
 
@@ -93,7 +84,7 @@ hapi:
     ##################################################
     #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
     allow_cascading_deletes: true
-    #    allow_contains_searches: true
+    allow_contains_searches: false
     allow_external_references: true
     allow_multiple_delete: true
     #    allow_override_default_search_params: true

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -44,7 +44,6 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
       hibernate.search.enabled: false
 hapi:
   fhir:

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -44,17 +44,8 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
-  ### lucene parameters
-#      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-#      hibernate.search.backend.directory.type: local-filesystem
-#      hibernate.search.backend.directory.root: target/lucenefiles
-#      hibernate.search.backend.lucene_version: lucene_current
-  ### elastic parameters ===> see also elasticsearch section below <===
-#      hibernate.search.backend.type: elasticsearch
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
+  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
+      hibernate.search.enabled: false
 hapi:
   fhir:
 
@@ -93,7 +84,7 @@ hapi:
     ##################################################
     #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
     allow_cascading_deletes: true
-    #    allow_contains_searches: true
+    allow_contains_searches: false
     allow_external_references: true
     allow_multiple_delete: true
     #    allow_override_default_search_params: true

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -44,7 +44,6 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
       hibernate.search.enabled: false
 hapi:
   fhir:

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -44,17 +44,8 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
-  ### lucene parameters
-#      hibernate.search.backend.type: lucene
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-#      hibernate.search.backend.directory.type: local-filesystem
-#      hibernate.search.backend.directory.root: target/lucenefiles
-#      hibernate.search.backend.lucene_version: lucene_current
-  ### elastic parameters ===> see also elasticsearch section below <===
-#      hibernate.search.backend.type: elasticsearch
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
+  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
+      hibernate.search.enabled: false
 hapi:
   fhir:
 
@@ -95,7 +86,7 @@ hapi:
     ##################################################
     #    allowed_bundle_types: COLLECTION,DOCUMENT,MESSAGE,TRANSACTION,TRANSACTIONRESPONSE,BATCH,BATCHRESPONSE,HISTORY,SEARCHSET
     allow_cascading_deletes: true
-    #    allow_contains_searches: true
+    allow_contains_searches: false
     allow_external_references: true
     allow_multiple_delete: true
     #    allow_override_default_search_params: true

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -44,7 +44,6 @@ spring:
   #      hibernate.cache.use_structured_entries: false
   #      hibernate.cache.use_minimal_puts: false
 
-  ### Hibernate Search disabled; set hibernate.search.enabled true and configure lucene/elasticsearch props to re-enable.
       hibernate.search.enabled: false
 hapi:
   fhir:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -31,17 +31,7 @@ spring:
       #      hibernate.cache.use_second_level_cache: false
       #      hibernate.cache.use_structured_entries: false
       #      hibernate.cache.use_minimal_puts: false
-      ###    These settings will enable fulltext search with lucene or elastic
       hibernate.search.enabled: false
-  ### lucene parameters
-  #      hibernate.search.backend.type: lucene
-  #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer
-  #      hibernate.search.backend.directory.type: local-filesystem
-  #      hibernate.search.backend.directory.root: target/lucenefiles
-  #      hibernate.search.backend.lucene_version: lucene_current
-  ### elastic parameters ===> see also elasticsearch section below <===
-#      hibernate.search.backend.type: elasticsearch
-#      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticAnalysisConfigurer
 
 hapi:
   fhir:
@@ -73,7 +63,7 @@ hapi:
     #      - Patient
     #      - Observation
     #    allow_cascading_deletes: true
-    #    allow_contains_searches: true
+    allow_contains_searches: false
     #    allow_external_references: true
     #    allow_multiple_delete: true
     #    allow_override_default_search_params: true


### PR DESCRIPTION
https://linear.app/metriport/issue/ENG-2402/optimize-current-hapi-fhir-server-install

### Dependencies

- Upstream: None
- Downstream: None

### Description

Turning off full text search in the yaml

From the logs, we appear to be using normal structured FHIR searches, with no signs of full-text search usage like _text or _content. Because of that, it should be safe to explicitly disable full-text search. This should help the write path because HAPI would no longer need to maintain an additional full-text index for resources we create or update. It also removes ambiguity from our ECS setup, since full-text search is currently enabled without an explicit backend configuration and may be falling back to local Lucene behavior.

### Testing

- Staging
  - [x] Double check server deploys properly
  - [x] Hit the server directly
  - [x] Confirm contains parameter no longer works
  - [x] Run DQ
  - [x] Run DR
- Production
  - [x] Double check server deploys properly
  - [ ] Hit the server directly
  - [ ] Confirm contains parameter no longer works
  - [ ] Run DQ
  - [ ] Run DR
  - [ ] Monitor nothing broke
  - [ ] Gather some metrics

### Release Plan
- [ ] Merge this
