### PR TITLE
eng2842: fix image conflict

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -20,22 +20,12 @@ on:
 
 jobs:
   deploy:
-    name: Deploy ${{ matrix.display_name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - cdk_stack: FHIRServerStack
-            display_name: FHIR Server
-            concurrency_group: fhir-server
-          - cdk_stack: FhirValidateServerStack
-            display_name: FHIR Validate Server
-            concurrency_group: fhir-validate
+    name: Deploy
     # prevents 2+ devs/workflows trying to deploy to AWS at the same time
     # https://serverlessfirst.com/emails/how-to-prevent-concurrent-deployments-of-serverless-stacks-in-github-actions/
     # TODO Consider the solution here: https://github.com/tj-actions/aws-cdk/blob/main/action.yml
     concurrency:
-      group: ${{ matrix.concurrency_group }}-${{ inputs.deploy_env }}
+      group: ${{ format('{0}-{1}', github.workflow, github.job) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.deploy_env }}
     defaults:
@@ -52,7 +42,6 @@ jobs:
         shell: bash
       - run: |
           echo "Git ref: $(git rev-parse HEAD)"
-          echo "Stack: ${{ matrix.cdk_stack }}"
         shell: bash
 
       # SET CONFIG FILES
@@ -77,12 +66,12 @@ jobs:
         working-directory: "./infra"
 
       # CDK DIFF
-      - name: Diff CDK stack
+      - name: Diff CDK stacks
         uses: metriport/deploy-with-cdk@2bacd2d78cc401947d3f459691e861b7deb05b8e
         with:
           cdk_action: "diff"
           cdk_version: "2.1105.0"
-          cdk_stack: ${{ matrix.cdk_stack }}
+          cdk_stack: "FHIRServerStack FhirValidateServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
           INPUT_PATH: "infra"
@@ -90,13 +79,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
-      # DEPLOY
-      - name: Deploy CDK stack
+      # DEPLOY — single cdk deploy publishes the shared Docker asset once
+      - name: Deploy CDK stacks
         uses: metriport/deploy-with-cdk@2bacd2d78cc401947d3f459691e861b7deb05b8e
         with:
           cdk_action: "deploy --verbose --require-approval never"
           cdk_version: "2.1105.0"
-          cdk_stack: ${{ matrix.cdk_stack }}
+          cdk_stack: "FHIRServerStack FhirValidateServerStack"
           cdk_env: "${{ inputs.deploy_env }}"
         env:
           INPUT_PATH: "infra"

--- a/infra/lib/fhir-server-stack.ts
+++ b/infra/lib/fhir-server-stack.ts
@@ -250,6 +250,7 @@ export class FHIRServerStack extends Stack {
 
     const dockerImage = new ecr_assets.DockerImageAsset(this, "FHIRImage", {
       directory: "../",
+      assetName: "fhir-server-image",
     });
 
     // Prep DB related data to the server

--- a/infra/lib/fhir-validate-server-stack.ts
+++ b/infra/lib/fhir-validate-server-stack.ts
@@ -96,6 +96,7 @@ export class FhirValidateServerStack extends Stack {
 
     const dockerImage = new ecr_assets.DockerImageAsset(this, "FHIRValidateImage", {
       directory: "../",
+      assetName: "fhir-server-image",
     });
 
     const fargateService =


### PR DESCRIPTION
### Dependencies

- Upstream: None
- Downstream: None

### Description

Fix ecr image conflict by putting both stacks into one cdk deploy call and giving names to the images. cdk should deduplicate these.

### Release Plan

- [x] Merge this
